### PR TITLE
Update task-installing-linux.adoc

### DIFF
--- a/task-installing-linux.adoc
+++ b/task-installing-linux.adoc
@@ -71,6 +71,9 @@ The installer for the Connector must access the following URLs during the instal
 +
 * \https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
 * \https://*.blob.core.windows.net or \https://hub.docker.com
+* \https://support.netapp.com and \https://mysupport.netapp.com
+* \https://*.cloudmanager.cloud.netapp.com and \https://cloudmanager.cloud.netapp.com 
+* \https://cloudmanagerinfraprod.azurecr.io
 +
 The host might try to update operating system packages during installation. The host can contact different mirroring sites for these OS packages.
 


### PR DESCRIPTION
Some outbound endpoints are missing on this documentation. 

https://support.netapp.com - To obtain licensing information and send AutoSupport messages to NetApp support. https://mysupport.netapp.com this one is being also used. I tested on a lab environment with fortigate firewall.  https://*.cloudmanager.cloud.netapp.com - To provide SaaS features and services within BlueXP. https://cloudmanager.cloud.netapp.com
https://cloudmanagerinfraprod.azurecr.io - To upgrade the Connector and its Docker components. https://*.blob.core.windows.net